### PR TITLE
Stack Memory

### DIFF
--- a/src/main/java/org/ai2ra/hso/simpic16f84/sim/mem/StackMemory.java
+++ b/src/main/java/org/ai2ra/hso/simpic16f84/sim/mem/StackMemory.java
@@ -63,13 +63,10 @@ public class StackMemory<T> implements ObservableMemory<T> {
     /**
      * @param address The memory address
      * @return Returns the data stored at the given address
-     * @deprecated Should be only used by external execution cores, for example if the stack
-     * pointer is implemented in a separate class or if something observes the memory itself
      * @throws MemoryIndexOutOfBoundsException Thrown if address violates the stack bounds
      */
 
     @Override
-    @Deprecated
     public T get(int address) throws MemoryIndexOutOfBoundsException {
 
         lock.readLock().lock();

--- a/src/test/java/org/ai2ra/hso/simpic16f84/sim/mem/StackMemoryTest.java
+++ b/src/test/java/org/ai2ra/hso/simpic16f84/sim/mem/StackMemoryTest.java
@@ -18,5 +18,26 @@ public class StackMemoryTest {
 
         stack.addPropertyChangeListener(event -> assertEquals((int) event.getNewValue(), 5));
         stack.push(5);
+
+        assertFalse(stack.isEmpty());
+        assertFalse(stack.isFull());
+    }
+
+    @Test public void popTest() {
+
+        stack.push(11);
+
+        stack.addPropertyChangeListener(event -> assertEquals((int) event.getNewValue(), 0));
+        assertEquals((int) stack.pop(), 11);
+    }
+
+    @Test public void isEmptyTest() {
+
+        assertTrue(stack.isEmpty());
+    }
+
+    @Test(expected = MemoryIndexOutOfBoundsException.class) public void getInvalidTest() {
+
+        stack.get(-5);
     }
 }


### PR DESCRIPTION
Generic implementation for the `StackMemory<T>`. Generic means width and number of entries is choosen dynamically.

- Synchronized with `ReadWriteLock`
- Implements `ObservableMemory<T>`
- Implemented generic `StackMemory<T>`